### PR TITLE
Add simple integrity check to parser

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -240,7 +240,7 @@ class TestParser(unittest.TestCase):
                 self.assertEqual(lines, expect)
 
     def test_021_gedcom_lines_errors(self):
-        """Test gedcom_lines method"""
+        """Test for exceptions raised by gedcom_lines method"""
 
         # tag name is only letters and digits
         data = b"0 HEAD\n1 CHAR ASCII\n1 SO@UR PIF PAF"
@@ -262,6 +262,27 @@ class TestParser(unittest.TestCase):
             with parser.GedcomReader(fname) as reader:
                 itr = reader.gedcom_lines(0)
                 self.assertRaises(parser.ParserError, list, itr)
+
+        # consistency check - nested levels
+        data = b"0 HEAD\n1 CHAR ASCII\n1 DATA\n3 MORE DATA"
+        with _temp_file(data) as fname:
+            with parser.GedcomReader(fname) as reader:
+                itr = reader.gedcom_lines(0)
+                self.assertRaises(parser.IntegrityError, list, itr)
+
+        # consistency check - CONC nesting
+        data = b"0 HEAD\n1 CHAR ASCII\n1 DATA adata\n1 CONC aadata"
+        with _temp_file(data) as fname:
+            with parser.GedcomReader(fname) as reader:
+                itr = reader.gedcom_lines(0)
+                self.assertRaises(parser.IntegrityError, list, itr)
+
+        # consistency check - CONT nesting
+        data = b"0 HEAD\n1 CHAR ASCII\n1 DATA adata\n1 CONT aadata"
+        with _temp_file(data) as fname:
+            with parser.GedcomReader(fname) as reader:
+                itr = reader.gedcom_lines(0)
+                self.assertRaises(parser.IntegrityError, list, itr)
 
     def test_030_read_record(self):
         """Test read_record method"""


### PR DESCRIPTION
Checks nesting of the records:
- level of the record can not increase by more than one from its preceding record
- level of CONT/CONC record must be +1 from its preceding regular record or the same as preceding CONT/CONC record