### PR TITLE
Add protection for empty DATE fields.

### DIFF
--- a/ged4py/detail/date.py
+++ b/ged4py/detail/date.py
@@ -217,6 +217,10 @@ class DateValue(object):
 
         :param str datestr: String with GEDCOM date, range, period, etc.
         """
+        # some apps generate DATE recods without any value, which is
+        # non-standard, return empty DateValue for those
+        if not datestr:
+            return cls()
         for regex, tmpl in DATES:
             m = regex.match(datestr)
             if m is not None:

--- a/ged4py/detail/name.py
+++ b/ged4py/detail/name.py
@@ -125,3 +125,18 @@ def parse_name_myher(record):
                       name_tuple[2],
                       maiden)
     return name_tuple
+
+def parse_name_ancestris(record):
+    """Parse NAME structure assuming ANCESTRIS dialect.
+
+    As far as I can tell Ancestris does not have any standard convention for
+    representing maiden or married names. Best we can do in this situation is
+    to use NAME record value and ignore any other fields.
+
+    :param record: NAME record
+    :return: tuple with 3 or 4 elements, first three elements of tuple are
+        the same as returned from :py:meth:`split_name` method, fourth element
+        (if present) denotes maiden name.
+    """
+    name_tuple = split_name(record.value)
+    return name_tuple

--- a/ged4py/model.py
+++ b/ged4py/model.py
@@ -8,7 +8,8 @@ from __future__ import print_function, absolute_import, division
 __all__ = ['make_record', 'Record', 'Pointer', 'NameRec', 'Name',
            'Date', 'Individual']
 
-from .detail.name import split_name, parse_name_altree, parse_name_myher
+from .detail.name import (split_name, parse_name_altree, parse_name_ancestris,
+                          parse_name_myher)
 from .detail.date import DateValue
 
 # Even though the structure of GEDCOM file is more or less fixed,
@@ -18,6 +19,7 @@ from .detail.date import DateValue
 DIALECT_DEFAULT = "DEF"
 DIALECT_MYHERITAGE = "MYHER"  # myheritage.com
 DIALECT_ALTREE = "AGELONG"  # Agelong Tree (genery.com)
+DIALECT_ANCESTRIS = "ANCESTRIS"  # Ancestris (ancestris.org)
 
 # Names/Individuals can be ordered differently, e.g. by surname first,
 # by given name first, or by maiden name first. This few constants define
@@ -207,6 +209,8 @@ class NameRec(Record):
             name_tuple = parse_name_altree(self)
         elif self.dialect in [DIALECT_MYHERITAGE]:
             name_tuple = parse_name_myher(self)
+        elif self.dialect in [DIALECT_ANCESTRIS]:
+            name_tuple = parse_name_ancestris(self)
         else:
             name_tuple = split_name(self.value)
         self.value = name_tuple

--- a/ged4py/parser.py
+++ b/ged4py/parser.py
@@ -223,8 +223,10 @@ class GedcomReader(object):
                 if source:
                     if source.value == "MYHERITAGE":
                         self._dialect = model.DIALECT_MYHERITAGE
-                    if source.value == "ALTREE":
+                    elif source.value == "ALTREE":
                         self._dialect = model.DIALECT_ALTREE
+                    elif source.value == "ANCESTRIS":
+                        self._dialect = model.DIALECT_ANCESTRIS
         return self._dialect
 
     @dialect.setter

--- a/tests/test_detail_date.py
+++ b/tests/test_detail_date.py
@@ -278,3 +278,13 @@ class TestDetailName(unittest.TestCase):
 
         # "empty" date is always later than any regular date
         self.assertTrue(DateValue() > DateValue.parse("2000"))
+
+    def test_018_date_parse_empty(self):
+        """Test detail.date.DateValue class."""
+
+        for value in (None, ""):
+            date = DateValue.parse(value)
+            self.assertTrue(date is not None)
+            self.assertEqual(date.template, "")
+            self.assertEqual(date.kw, {})
+            self.assertEqual(date.fmt(), "")

--- a/tests/test_detail_name.py
+++ b/tests/test_detail_name.py
@@ -5,7 +5,8 @@
 
 import unittest
 
-from ged4py.detail.name import split_name, parse_name_altree, parse_name_myher
+from ged4py.detail.name import (split_name, parse_name_altree,
+                                parse_name_myher, parse_name_ancestris)
 from ged4py import model
 
 
@@ -107,3 +108,29 @@ class TestDetailName(unittest.TestCase):
         name_tup = parse_name_myher(rec)
         self.assertIsInstance(name_tup, tuple)
         self.assertEqual(name_tup, ("First", "Married", "", "Maiden"))
+
+    def test_004_parse_name_ancestris(self):
+        """Test parse_name_ancestris()
+
+        Ancestris dialect is just a split_name() which is tested separately,
+        so the is not much testing needed for it.
+        """
+        rec = model.NameRec()
+        rec.level = 1
+        rec.tag = "NAME"
+        rec.dialect = model.DIALECT_ANCESTRIS
+
+        rec.value = "First /Last Name/ Second"
+        name_tup = parse_name_ancestris(rec)
+        self.assertIsInstance(name_tup, tuple)
+        self.assertEqual(name_tup, ("First", "Last Name", "Second"))
+
+        rec.value = "First /Last(-er)/ Second"
+        name_tup = parse_name_ancestris(rec)
+        self.assertIsInstance(name_tup, tuple)
+        self.assertEqual(name_tup, ("First", "Last(-er)", "Second"))
+
+        rec.value = "First /Last (-er)/ Second"
+        name_tup = parse_name_ancestris(rec)
+        self.assertIsInstance(name_tup, tuple)
+        self.assertEqual(name_tup, ("First", "Last (-er)", "Second"))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -324,6 +324,18 @@ class TestModel(unittest.TestCase):
         self.assertIsInstance(date, model.Date)
         self.assertIsInstance(date.value, DateValue)
 
+        # empty date tag makes Date with empty DateValue
+        dialect = model.DIALECT_DEFAULT
+        date = model.make_record(1, None, "DATE", None, [], 0, dialect).freeze()
+        self.assertIsInstance(date, model.Date)
+        self.assertIsInstance(date.value, DateValue)
+        self.assertEqual(date.value.template, "")
+
+        date = model.make_record(1, None, "DATE", "", [], 0, dialect).freeze()
+        self.assertIsInstance(date, model.Date)
+        self.assertIsInstance(date.value, DateValue)
+        self.assertEqual(date.value.template, "")
+
     def test_040_Pointer(self):
         """Test Pointer class."""
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -190,6 +190,11 @@ class TestParser(unittest.TestCase):
             with parser.GedcomReader(fname) as reader:
                 self.assertEqual(reader.dialect, model.DIALECT_ALTREE)
 
+        data = b"0 HEAD\n1 SOUR ANCESTRIS\n0 TRLR"
+        with _temp_file(data) as fname:
+            with parser.GedcomReader(fname) as reader:
+                self.assertEqual(reader.dialect, model.DIALECT_ANCESTRIS)
+
         data = b"0 HEAD\n1 SOUR XXX\n0 TRLR"
         with _temp_file(data) as fname:
             with parser.GedcomReader(fname) as reader:


### PR DESCRIPTION
Ancestris application tends to make DATE records with no value which is
not expected by ged4py. Add simple workaround for those non-standard
tags. Also added rudimentary support for Ancestris dialect and name
format (Ancestris does not seem to have any convention for
maiden/married names).)