### PR TITLE
Extend `Record.sub_tags()` behavior.

### DIFF
--- a/ged4py/calendar.py
+++ b/ged4py/calendar.py
@@ -253,9 +253,9 @@ class CalendarDate(metaclass=abc.ABCMeta):
         if m is None:
             raise ValueError("Failed to parse date: " + datestr)
 
-        calendar = m.group(1) or "GREGORIAN"
+        calendar_name = m.group(1) or "GREGORIAN"
         try:
-            calendar = CalendarType(calendar)
+            calendar = CalendarType(calendar_name)
         except ValueError:
             raise ValueError("Unknown calendar: " + datestr)
         day = None if m.group(2) is None else int(m.group(2))
@@ -360,7 +360,6 @@ class GregorianDate(CalendarDate):
         year = self.dual_year if self.dual_year is not None else self.year
         if self.bc:
             year = - year
-        month = self.month_num
         day = self.day
         offset = 0.
         if self.month_num is None:
@@ -370,12 +369,14 @@ class GregorianDate(CalendarDate):
             day = 1
             offset = 1.
         elif self.day is None:
-            month += 1
+            month = self.month_num + 1
             if month == 13:
                 month -= 12
                 year += 1
             day = 1
             offset = 1.
+        else:
+            month = self.month_num
 
         dates = [
             (year, month, day, offset),
@@ -438,7 +439,6 @@ class JulianDate(CalendarDate):
         calendar = convertdate.julian
 
         year = - self.year if self.bc else self.year
-        month = self.month_num
         day = self.day
         offset = 0.
         if self.month_num is None:
@@ -448,12 +448,14 @@ class JulianDate(CalendarDate):
             day = 1
             offset = 1.
         elif self.day is None:
-            month += 1
+            month = self.month_num + 1
             if month == 13:
                 month -= 12
                 year += 1
             day = 1
             offset = 1.
+        else:
+            month = self.month_num
 
         dates = [
             (year, month, day, offset),

--- a/ged4py/detail/io.py
+++ b/ged4py/detail/io.py
@@ -4,6 +4,7 @@
 import codecs
 import io
 import os
+from typing import List
 
 
 def check_bom(file):
@@ -77,7 +78,7 @@ class BinaryFileCR(io.BufferedReader):
     def readline(self, limit=-1):
         if limit == 0:
             return b""
-        data = []
+        data: List[bytes] = []
         while True:
             byte = self.read(1)
             if not byte:

--- a/ged4py/model.py
+++ b/ged4py/model.py
@@ -3,7 +3,7 @@
 """Module containing Python in-memory model for GEDCOM data.
 """
 
-from __future__ import annotations
+# from __future__ import annotations
 
 __all__ = ['make_record', 'Record', 'Pointer', 'NameRec', 'Name',
            'Date', 'Individual']
@@ -129,7 +129,7 @@ class Record:
         self.offset = None
         self.dialect = None
 
-    def freeze(self) -> Record:
+    def freeze(self) -> 'Record':
         """Method called by parser when updates to this record finish.
 
         Some sub-classes will override this method to implement conversion
@@ -142,7 +142,7 @@ class Record:
         """
         return self
 
-    def sub_tag(self, path, follow=True) -> Optional[Record]:
+    def sub_tag(self, path, follow=True) -> Optional['Record']:
         """Finds and returns sub-record with given tag name.
 
         Path can be a simple tag name, in which case the first direct
@@ -210,7 +210,7 @@ class Record:
             return rec.value
         return None
 
-    def sub_tags(self, *tags: str, follow: bool = True) -> List[Record]:
+    def sub_tags(self, *tags: str, follow: bool = True) -> List['Record']:
         """Returns a list of sub-records matching any tag name.
 
         If no positional arguments are provided then all direct sub-records of

--- a/ged4py/model.py
+++ b/ged4py/model.py
@@ -3,10 +3,13 @@
 """Module containing Python in-memory model for GEDCOM data.
 """
 
+from __future__ import annotations
+
 __all__ = ['make_record', 'Record', 'Pointer', 'NameRec', 'Name',
            'Date', 'Individual']
 
 import enum
+from typing import Any, Iterator, List, Optional, Union
 
 from .detail.name import (split_name, parse_name_altree, parse_name_ancestris,
                           parse_name_myher)
@@ -126,7 +129,7 @@ class Record:
         self.offset = None
         self.dialect = None
 
-    def freeze(self):
+    def freeze(self) -> Record:
         """Method called by parser when updates to this record finish.
 
         Some sub-classes will override this method to implement conversion
@@ -139,7 +142,7 @@ class Record:
         """
         return self
 
-    def sub_tag(self, path, follow=True):
+    def sub_tag(self, path, follow=True) -> Optional[Record]:
         """Finds and returns sub-record with given tag name.
 
         Path can be a simple tag name, in which case the first direct
@@ -183,7 +186,7 @@ class Record:
                     return rec
         return None
 
-    def sub_tag_value(self, path, follow=True):
+    def sub_tag_value(self, path, follow=True) -> Any:
         """Returns value of a direct sub-record.
 
         Works as `sub_tag()` but returns value of a sub-record instead of
@@ -207,17 +210,23 @@ class Record:
             return rec.value
         return None
 
-    def sub_tags(self, *tags, follow=True):
-        """Returns list of immediate sub-records matching any tag name.
+    def sub_tags(self, *tags: str, follow: bool = True) -> List[Record]:
+        """Returns a list of sub-records matching any tag name.
 
-        Unlike `sub_tag` method this method does not support
-        hierarchical paths. It resolves pointer records if ``follow``
-        keyword argument is ``True`` (default).
+        If no positional arguments are provided then all direct sub-records of
+        this record are returned, pointers are resolved if ``follow`` is True.
+        If one or more positional arguments are given then this method returns
+        all sub-records, direct or nested, that match any of the given tags.
+
+        If ``follow`` is True then pointer records are resolved and pointed
+        record is used instead of pointer record, this also works for all
+        intermediate records in a path.
 
         Parameters
         ----------
         *tags : `str`
-            Names of the sub-record tag
+            Each positional argument is one or more tag names separated by
+            slashes.
         follow : `bool`, optional
             If True then resolve pointers.
 
@@ -226,16 +235,40 @@ class Record:
         records : `list` [ `Record` ]
             List of records, possibly empty.
         """
-        records = [x for x in self.sub_records if x.tag in tags]
-        if follow:
-            records = [rec.ref if isinstance(rec, Pointer) else rec
-                       for rec in records]
+        def _sub_tags(record: Record, tag_matches: List[List[str]], my_tag: List[str]) -> Iterator[Record]:
+            assert record.sub_records is not None
+            for rec in record.sub_records:
+                sub_tag = my_tag + [rec.tag]
+                for m in tag_matches:
+                    if m[:len(sub_tag)] == sub_tag:
+                        if follow and isinstance(rec, Pointer):
+                            rec = rec.ref
+                        if len(sub_tag) == len(m):
+                            yield rec
+                        else:
+                            yield from _sub_tags(rec, tag_matches, sub_tag)
+                        break
+
+        assert self.sub_records is not None
+        if not tags:
+            # return all direct sub-tgas
+            records = [x for x in self.sub_records]
+            if follow:
+                records = [rec.ref if isinstance(rec, Pointer) else rec
+                           for rec in records]
+        else:
+            records = []
+
+            # this ignores empty tags
+            tag_matches = [tag.split("/") for tag in tags if tag]
+            records += list(_sub_tags(self, tag_matches, []))
+
         return records
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self.__str__()
 
-    def __str__(self):
+    def __str__(self) -> str:
         value = self.value
         if isinstance(value, str) and len(value) > 32:
             value = value[:32] + "..."
@@ -249,7 +282,7 @@ class Record:
         return fmt.format(self.__class__.__name__, self, value, n_sub)
 
     # Records cannot be hashed
-    __hash__ = None
+    __hash__ = None  # type: ignore
 
 
 class Pointer(Record):
@@ -275,7 +308,7 @@ class Pointer(Record):
     def __init__(self, parser):
         Record.__init__(self)
         self.parser = parser
-        self._value = []  # use non-None to signify non-initialized
+        self._value: Any = []  # use non-None to signify non-initialized
 
     @property
     def ref(self):
@@ -377,7 +410,7 @@ class Name:
     def __init__(self, names, dialect):
         self._names = names
         self._dialect = dialect
-        self._primary = None  # "primary" name record
+        self._primary: Record  # "primary" name record
 
         if len(names) == 0:
             # make fake name record to simplify logic below
@@ -396,11 +429,13 @@ class Name:
     @property
     def surname(self):
         """Person surname (`str`)"""
+        assert self._primary.value is not None
         return self._primary.value[1]
 
     @property
     def given(self):
         """Given name could include both first and middle name (`str`)"""
+        assert self._primary.value is not None
         if self._primary.value[0] and self._primary.value[2]:
             return self._primary.value[0] + ' ' + self._primary.value[2]
         return self._primary.value[0] or self._primary.value[2]
@@ -422,8 +457,8 @@ class Name:
                 if name.type == "maiden":
                     return name.value[1]
         # rely on NameRec extracting it from other source
-        if self._primary and len(self._primary.value) > 3:
-            return self._primary.value[3]
+        if self._primary and len(self._primary.value) > 3:  # type: ignore
+            return self._primary.value[3]  # type: ignore
         return None
 
     def order(self, order):
@@ -472,15 +507,15 @@ class Name:
         name : `str`
             Formatted name representation.
         """
-        name = self._primary.value[0]
+        name = self._primary.value[0]  # type: ignore
         if self.surname:
             if name:
                 name += ' '
             name += self.surname
-        if self._primary.value[2]:
+        if self._primary.value[2]:  # type: ignore
             if name:
                 name += ' '
-            name += self._primary.value[2]
+            name += self._primary.value[2]  # type: ignore
         return name
 
     def __str__(self):
@@ -521,8 +556,8 @@ class Individual(Record):
     """
     def __init__(self):
         Record.__init__(self)
-        self._mother = []  # Non-None as uninitialized
-        self._father = []  # Non-None as uninitialized
+        self._mother: Optional[Union[Record, List]] = []  # Non-None as uninitialized
+        self._father: Optional[Union[Record, List]] = []  # Non-None as uninitialized
 
     @property
     def name(self):
@@ -562,7 +597,7 @@ _tag_class = dict(INDI=Individual,
 
 
 def make_record(level, xref_id, tag, value, sub_records, offset, dialect,
-                parser=None):
+                parser=None) -> Record:
     """Create `Record` instance based on parameters.
 
     Parameters
@@ -610,12 +645,12 @@ def make_record(level, xref_id, tag, value, sub_records, offset, dialect,
     record construction.
     """
     # value can be bytes or string so we check for both, 64 is code for '@'
+    rec: Record
     if value and len(value) > 2 and \
         ((value[0] == '@' and value[-1] == '@') or
          (value[0] == 64 and value[-1] == 64)):
         # this looks like a <pointer>, make a Pointer record
-        klass = Pointer
-        rec = klass(parser)
+        rec = Pointer(parser)
     else:
         klass = _tag_class.get(tag, Record)
         rec = klass()

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,19 @@
+[mypy]
+warn_unused_configs = True
+warn_redundant_casts = True
+
+[mypy-convertdate.*]
+ignore_missing_imports = True
+
+[mypy-ansel.*]
+ignore_missing_imports = True
+
+[mypy-ged4py.*]
+ignore_missing_imports = False
+ignore_errors = False
+check_untyped_defs = True
+#disallow_untyped_defs = True
+#disallow_incomplete_defs = True
+strict_equality = True
+warn_unreachable = True
+warn_unused_ignores = True

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -94,6 +94,26 @@ class TestModel(unittest.TestCase):
         self.assertEqual(rec.sub_tag("SUBB/SUB").tag, "SUB")
         self.assertEqual(rec.sub_tag_value("SUBB/SUB"), "VALUE")
 
+        subs = rec.sub_tags()
+        self.assertCountEqual([sub.tag for sub in subs], ['SUBA', 'SUBB', 'SUBC'] * 3)
+        subs = rec.sub_tags("SUBA")
+        self.assertCountEqual([sub.tag for sub in subs], ['SUBA'] * 3)
+        subs = rec.sub_tags("SUBB", "SUBC")
+        self.assertCountEqual([sub.tag for sub in subs], ['SUBB', 'SUBC'] * 3)
+
+        subs = rec.sub_tags("SUBA/SUB")
+        self.assertCountEqual([sub.tag for sub in subs], ['SUB'] * 3)
+        subs = rec.sub_tags("SUBB/SUB", "SUBC/SUB")
+        self.assertCountEqual([sub.tag for sub in subs], ['SUB'] * 6)
+        subs = rec.sub_tags("SUBB/SUB", "SUBA")
+        self.assertCountEqual([sub.tag for sub in subs], ['SUB', 'SUBA'] * 3)
+        subs = rec.sub_tags("SUBA", "SUBA")
+        self.assertCountEqual([sub.tag for sub in subs], ['SUBA'] * 3)
+        subs = rec.sub_tags("SUBA/SUB", "SUBA/SUB")
+        self.assertCountEqual([sub.tag for sub in subs], ['SUB'] * 3)
+        subs = rec.sub_tags("SUBA/SUB/SUBB")
+        self.assertEqual(len(subs), 0)
+
     def test_003_record_nohash(self):
         """Test that records are non-hashable"""
 


### PR DESCRIPTION
Without positions arguments `sub_tags()` now returns all direct sub-tags
of a record. If positional arguments are provided they can be
hierarchical tags (slash-separated), and in that case all sub-tags that
match any of the provided tags are turned.

Also I did an initial run of `mypy` with relaxed rules and fixed few of
the potential issues reported by `mypy`.